### PR TITLE
Minor Fix for HTTP and HTTP forward Check

### DIFF
--- a/get5_auto_installer.sh
+++ b/get5_auto_installer.sh
@@ -4,7 +4,7 @@
 # Credits : Splewis , PhlexPlexico 
 # Purpose: Get5 Web API Panel installation script
 # Website : 
-version="0.95"
+version="0.99"
 
 # Checking for Root
 if [[ $EUID -ne 0 ]]; then
@@ -58,7 +58,7 @@ fi
 		echo "Please Enter Panel Address without http or https protocol"
 		read sitename
 		echo "You have entered $sitename"
-		while [[ $sitename == *"http"* || $sitename == *"https"* ]];
+		while [[ $sitename == http* || $sitename == https* ]];
 		do
 			echo "Please re-enter Website Address without http or https"
 			read -r sitename


### PR DESCRIPTION
Before if sitename had anywhere HTTP and HTTPS mentioned even in domain name it would not allow people to use that website. With this small fix it will only check for forward http and https protocol